### PR TITLE
Define Mailer and port example to an exe that can crudely register stuff

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,8 +1,33 @@
 module Main where
 
+import Control.Concurrent.Async
+import qualified Control.Concurrent.Chan.Unagi as U
+import Control.Monad
+import Data.DateTime (getCurrentTime)
+import qualified Data.Text as Text
+import qualified Data.UUID as UUID
 import System.Environment (getEnv)
 
 import Lib
+import Registration
+import Mailer
 
 main :: IO ()
-main = getEnv "PORT" >>= someFunc . read
+-- main = getEnv "PORT" >>= someFunc . read
+main = do
+  ms <- settingsFromEnv UUID.toText UUID.toText
+  store <- newStore
+  o <- sGetNotificationChan store
+  let actor = newActor getCurrentTime
+  withAsync (mailer ms store (U.readChan o)) $ \a -> forever $ do
+    putStrLn "Command pls: s <email>, v <uuid>, u <uuid>"
+    input <- getLine
+    case input of
+      's':' ':email -> let e = Text.pack email in
+        aSubmitEmailAddress actor e store (mockEmailToUuid e)
+      'v':' ':uuid -> parseUuidThen (\u -> aVerify actor store u) uuid
+      'u':' ':uuid -> parseUuidThen (\u -> aUnsubscribe actor store u) uuid
+      'g':' ':uuid -> parseUuidThen (getAndShowState store) uuid
+      _ -> putStrLn "Narp, try again"
+  where
+    parseUuidThen f uuid = maybe (putStrLn "rubbish uuid") f $ UUID.fromString uuid

--- a/src/Mailer.hs
+++ b/src/Mailer.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Mailer where
+
+import Data.Maybe
+import Data.DateTime (getCurrentTime)
+import Data.Text (Text)
+import Data.Text.Format (format)
+import Data.UUID (UUID)
+import System.Environment (getEnv, lookupEnv)
+
+import qualified Network.HaskellNet.SMTP.SSL as SMTP
+import qualified Network.Mail.Mime as Mime
+
+import Registration (
+  EmailType(..), UserEvent(Emailed), UserState(..), Store, condenseConsecutive,
+  reactivelyRunAction, timeStampedAction)
+
+-- FIXME: we could extend this not to assume a port or using TLS (c.f STARTTLS)
+data MailerSettings = MailerSettings
+  { msSmtpSslSettings :: SMTP.Settings
+  , msServer :: String
+  , msUsername :: String
+  , msPassword :: String
+  , msSenderAddress :: Mime.Address
+  , msVerifiationLinkFormatter :: LinkFormatter
+  , msUnsubscribeLinkFormatter :: LinkFormatter
+  }
+
+instance Show MailerSettings where
+  show ms = "poop"
+
+type LinkFormatter = UUID -> Text
+
+
+settingsFromEnv :: LinkFormatter -> LinkFormatter -> IO MailerSettings
+settingsFromEnv formatVLink formatULink =
+    buildEnv
+      <$> lookupEnv "SMTP_LOGGING"
+      <*> getEnv "SMTP_SERVER"
+      <*> getEnv "SMTP_USERNAME"
+      <*> getEnv "SMTP_PASSWORD"
+  where
+    buildEnv ml s u p = MailerSettings
+      { msSmtpSslSettings = SMTP.defaultSettingsSMTPSSL
+        { SMTP.sslLogToConsole = maybe False (not . null) ml }
+      , msServer = s
+      , msUsername = u
+      , msPassword = p
+      , msSenderAddress =
+          Mime.Address (Just "Concert") "noreply@concertdaw.co.uk"
+      , msVerifiationLinkFormatter = formatVLink
+      , msUnsubscribeLinkFormatter = formatULink
+      }
+
+
+sendEmails :: MailerSettings -> [Mime.Mail] -> IO ()
+sendEmails settings mails =
+    SMTP.doSMTPSSLWithSettings
+      (msServer settings)
+      (msSmtpSslSettings settings) $ \conn -> do
+    authSuccess <- SMTP.authenticate
+      SMTP.LOGIN (msUsername settings) (msPassword settings) conn
+    if authSuccess
+      then mapM_ (flip SMTP.sendMimeMail2 conn) mails
+      else putStrLn "SMTP: authentication error."
+
+
+verificationEmail :: Mime.Address -> Mime.Address -> Text -> Text -> Mime.Mail
+verificationEmail from to verificationLink unsubscribeLink =
+    Mime.simpleMail' to from subject body
+  where
+    subject = "Please verify your email address"
+    -- FIXME: format isn't type-checked, so we need to write tests for these
+    -- functions to make sure we haven't mis-matched our arguments
+    body = format
+      "Some kind of nicely formatted body with {} and {} in the middle"
+      [verificationLink, unsubscribeLink]
+
+confirmationEmail :: Mime.Address -> Mime.Address -> Text -> Mime.Mail
+confirmationEmail from to unsubscribeLink =
+    Mime.simpleMail' to from subject body
+  where
+    subject = "Subscription confirmed"
+    body = format
+      "You've already signed up etc... Unsubscribe with {}" [unsubscribeLink]
+
+
+generateEmail :: MailerSettings -> UUID -> UserState -> EmailType -> Mime.Mail
+generateEmail settings uuid userState emailType =
+    case emailType of
+      VerificationEmail -> verificationEmail from to vl ul
+      ConfirmationEmail -> confirmationEmail from to ul
+  where
+    to = Mime.Address Nothing $ usEmailAddress userState
+    from = msSenderAddress settings
+    vl = msVerifiationLinkFormatter settings uuid
+    ul = msUnsubscribeLinkFormatter settings uuid
+
+
+mailer :: MailerSettings -> Store -> IO (Maybe UUID) -> IO ()
+mailer settings = reactivelyRunAction
+    (timeStampedAction getCurrentTime action)
+  where
+    action uuid userState =
+      let
+        pending = condenseConsecutive $ usPendingEmails userState
+        emails = generateEmail settings uuid userState <$> pending
+      in
+        sendEmails settings emails >> return (Emailed <$> pending)

--- a/src/Mailer.hs
+++ b/src/Mailer.hs
@@ -28,7 +28,13 @@ data MailerSettings = MailerSettings
   }
 
 instance Show MailerSettings where
-  show ms = "poop"
+  show ms = (
+       "MailerSettings\n"
+    ++ "  { msSmtpSslSettings = " ++ show (msSmtpSslSettings ms) ++ "\n"
+    ++ "  { msServer = " ++ show (msServer ms) ++ "\n"
+    ++ "  { msUsername = " ++ show (msUsername ms) ++ "\n"
+    ++ "  { msPassword = ****\n"
+    ++ "  { msSenderAddress = " ++ show (msSenderAddress ms) ++ "\n")
 
 type LinkFormatter = UUID -> Text
 

--- a/src/Registration.hs
+++ b/src/Registration.hs
@@ -223,25 +223,6 @@ mockEmailToUuid :: EmailAddress -> UUID
 mockEmailToUuid = uuidFromInteger . fromIntegral . Text.length
 
 
-testLoop :: IO ()
-testLoop = do
-  store <- newStore
-  o <- sGetNotificationChan store
-  let actor = newActor getCurrentTime
-  withAsync (reactivelyRunAction tsSendEmails store (U.readChan o)) $ \a -> forever $ do
-    putStrLn "Command pls: s <email>, v <uuid>, u <uuid>"
-    input <- getLine
-    case input of
-      's':' ':email -> let e = Text.pack email in
-        aSubmitEmailAddress actor e store (mockEmailToUuid e)
-      'v':' ':uuid -> parseUuidThen (\u -> aVerify actor store u) uuid
-      'u':' ':uuid -> parseUuidThen (\u -> aUnsubscribe actor store u) uuid
-      'g':' ':uuid -> parseUuidThen (getAndShowState store) uuid
-      _ -> putStrLn "Narp, try again"
-  where
-    parseUuidThen f uuid = maybe (putStrLn "rubbish uuid") f $ UUID.fromString uuid
-
-
 reactivelyRunAction ::
     Action (TimeStamped UserEvent) -> Store -> IO (Maybe UUID) -> IO ()
 reactivelyRunAction a store read =

--- a/warp-test.cabal
+++ b/warp-test.cabal
@@ -16,6 +16,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Lib
+                     , Mailer
                      , Middleware
                      , Registration
                      , Router
@@ -26,11 +27,13 @@ library
                      , eventful-core
                      , eventful-memory
                      , http-types
+                     , mime-mail
                      , neat-interpolation
-                     , smtp-mail
+                     , HaskellNet-SSL
                      , stm
                      , time
                      , text
+                     , text-format
                      , unagi-chan
                      , urlencoded
                      , utf8-string
@@ -45,6 +48,11 @@ executable warp-test-exe
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
+                     , async
+                     , datetime
+                     , text
+                     , unagi-chan
+                     , uuid
                      , warp-test
   default-language:    Haskell2010
 


### PR DESCRIPTION
This does quite do All The Things yet, but it can send email in reaction to subscription events _generated in the terminal_. You need to set the following environment vars to make it go: `SMTP_SERVER`, `SMTP_USERNAME`, `SMTP_PASSWORD`. If in addition you set `SMTP_LOGGING` to any non-empty value, you'll get a log from `HaskellNet-SSL` letting you know what's going on with sending the emails.