### PR TITLE
Persistence

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -18,7 +18,7 @@ main :: IO ()
 -- main = getEnv "PORT" >>= someFunc . read
 main = do
   ms <- settingsFromEnv UUID.toText UUID.toText
-  store <- newStore
+  store <- newDBStore
   o <- sGetNotificationChan store
   let actor = newActor "NaCl" getCurrentTime
   go ms store actor o

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -18,7 +18,7 @@ main :: IO ()
 -- main = getEnv "PORT" >>= someFunc . read
 main = do
   ms <- settingsFromEnv UUID.toText UUID.toText
-  store <- newDBStore
+  store <- getDatabaseConfig >>= newDBStore
   o <- sGetNotificationChan store
   let actor = newActor "NaCl" getCurrentTime
   go ms store actor o

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -38,6 +38,7 @@ main = do
               'u':' ':uuid ->
                   parseUuidThen (\u -> aUnsubscribe actor store u) uuid >>
                   go ms store actor o
-              'g':' ':uuid -> parseUuidThen (getAndShowState store) uuid
+              'g':' ':uuid -> parseUuidThen (getAndShowState store) uuid >>
+                  go ms store actor o
               'q':_ -> sSendShutdown store
               _ -> putStrLn "Narp, try again" >> go ms store actor o

--- a/src/Mailer.hs
+++ b/src/Mailer.hs
@@ -113,4 +113,6 @@ mailer settings = reactivelyRunAction
         pending = condenseConsecutive $ usPendingEmails userState
         emails = generateEmail settings uuid userState <$> pending
       in
-        sendEmails settings emails >> return (Emailed <$> pending)
+        case emails of
+          [] -> return []
+          emails -> sendEmails settings emails >> return (Emailed <$> pending)

--- a/src/Mailer.hs
+++ b/src/Mailer.hs
@@ -61,14 +61,15 @@ settingsFromEnv formatVLink formatULink =
 
 
 sendEmails :: MailerSettings -> [Mime.Mail] -> IO ()
-sendEmails settings mails =
+sendEmails settings [] = return ()
+sendEmails settings emails =
     SMTP.doSMTPSSLWithSettings
       (msServer settings)
       (msSmtpSslSettings settings) $ \conn -> do
     authSuccess <- SMTP.authenticate
       SMTP.LOGIN (msUsername settings) (msPassword settings) conn
     if authSuccess
-      then mapM_ (flip SMTP.sendMimeMail2 conn) mails
+      then mapM_ (flip SMTP.sendMimeMail2 conn) emails
       else putStrLn "SMTP: authentication error."
 
 
@@ -113,6 +114,4 @@ mailer settings = reactivelyRunAction
         pending = condenseConsecutive $ usPendingEmails userState
         emails = generateEmail settings uuid userState <$> pending
       in
-        case emails of
-          [] -> return []
-          emails -> sendEmails settings emails >> return (Emailed <$> pending)
+        sendEmails settings emails >> return (Emailed <$> pending)

--- a/src/Registration.hs
+++ b/src/Registration.hs
@@ -150,9 +150,6 @@ userCommandHandler now =
   CommandHandler (handleUserCommand now) initialUserProjection
 
 
-type Reader = VersionedEventStoreReader STM (TimeStamped UserEvent)
-type Writer = VersionedEventStoreWriter STM (TimeStamped UserEvent)
-
 data Store = Store
   { sGetNotificationChan :: IO (U.OutChan (Maybe UUID))
   -- FIXME: sendShutdown feels weird, because it doesn't mean anything to

--- a/src/Registration.hs
+++ b/src/Registration.hs
@@ -19,6 +19,10 @@ import Data.Time.Clock (
 import Data.UUID (UUID, nil)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUIDv5
+import System.Environment (getEnv)
+
+import Database.Persist.URL (fromDatabaseUrl)
+import qualified Database.Persist.Postgresql as DB
 
 import Eventful (
   Projection(..), CommandHandler(..), getLatestStreamProjection,
@@ -251,3 +255,7 @@ sendEmails uuid s =
 
 tsSendEmails :: Action (TimeStamped UserEvent)
 tsSendEmails = timeStampedAction getCurrentTime sendEmails
+
+
+getDatabaseConfig :: IO DB.PostgresConf
+getDatabaseConfig = join $ fromDatabaseUrl 1 <$> getEnv "DATABASE_URL"

--- a/src/Registration.hs
+++ b/src/Registration.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Registration where
 
@@ -8,6 +9,8 @@ import qualified Control.Concurrent.Chan.Unagi as U
 import Control.Concurrent.STM (STM, atomically)
 import Control.Monad
 import qualified Crypto.Hash.SHA256 as SHA256
+import Data.Aeson.TH (deriveJSON)
+import Data.Aeson.Casing (aesonPrefix, camelCase)
 import qualified Data.ByteString as BS
 import Data.DateTime (DateTime, getCurrentTime)
 import Data.Monoid
@@ -259,3 +262,8 @@ tsSendEmails = timeStampedAction getCurrentTime sendEmails
 
 getDatabaseConfig :: IO DB.PostgresConf
 getDatabaseConfig = join $ fromDatabaseUrl 1 <$> getEnv "DATABASE_URL"
+
+
+deriveJSON (aesonPrefix camelCase) ''EmailType
+deriveJSON (aesonPrefix camelCase) ''VerificationState
+deriveJSON (aesonPrefix camelCase) ''UserEvent

--- a/src/Registration.hs
+++ b/src/Registration.hs
@@ -29,8 +29,9 @@ import Database.Persist.URL (fromDatabaseUrl)
 import qualified Database.Persist.Postgresql as DB
 
 import Eventful (
-  Projection(..), CommandHandler(..), getLatestStreamProjection,
-  versionedStreamProjection, streamProjectionState, uuidFromInteger)
+  Projection(..), CommandHandler(..), StreamProjection, EventVersion,
+  getLatestStreamProjection, versionedStreamProjection, streamProjectionState,
+  uuidFromInteger)
 import Eventful.Store.Class (
   VersionedEventStoreWriter, VersionedEventStoreReader)
 import Eventful.Store.Memory (
@@ -153,9 +154,7 @@ type Reader = VersionedEventStoreReader STM (TimeStamped UserEvent)
 type Writer = VersionedEventStoreWriter STM (TimeStamped UserEvent)
 
 data Store = Store
-  { _sReader :: Reader
-  , _sWriter :: Writer
-  , sGetNotificationChan :: IO (U.OutChan (Maybe UUID))
+  { sGetNotificationChan :: IO (U.OutChan (Maybe UUID))
   -- FIXME: sendShutdown feels weird, because it doesn't mean anything to
   -- actually writing to the store...
   , sSendShutdown :: IO ()
@@ -164,24 +163,36 @@ data Store = Store
   , sPoll :: UUID -> IO UserState
   }
 
+newStoreFrom
+  :: (UUID -> [TimeStamped UserEvent] -> IO ())
+  -> (UUID -> IO (
+         StreamProjection UUID EventVersion UserState (TimeStamped UserEvent))
+     )
+  -> IO Store
+newStoreFrom write getLatestUserProjection = do
+    -- We assume that the unused OutChan gets cleaned up when it goes out of
+    -- scope:
+    (i, _) <- U.newChan
+    let update a uuid = do
+            events <- getLatestState uuid >>= a uuid
+            write uuid events
+            when (not . null $ events) $ U.writeChan i (Just uuid)
+        getLatestState uuid =
+            streamProjectionState <$> getLatestUserProjection uuid
+    return $
+      Store (U.dupChan i) (U.writeChan i Nothing) update getLatestState
+
 newStore :: IO Store
 newStore = do
     tvar <- eventMapTVar
     let
       w = tvarEventStoreWriter tvar
       r = tvarEventStoreReader tvar
-    -- We assume that the unused OutChan gets cleaned up when it goes out of scope
-    (i, _) <- U.newChan
-    let
-        update a uuid = do
-            events <- getLatestState uuid >>= a uuid
-            writeEvents w uuid events
-            -- FIXME: we now can't "shut down" the store...
-            when (not . null $ events) $ U.writeChan i (Just uuid)
-        getLatestState uuid =
-            streamProjectionState <$> getLatestUserProjection r uuid
-    return $
-      Store r w (U.dupChan i) (U.writeChan i Nothing) update getLatestState
+    -- FIXME: AnyPosition always valid?
+    newStoreFrom
+      (\uuid -> void . atomically . storeEvents w uuid AnyPosition)
+      (\uuid -> atomically $ getLatestStreamProjection r $
+          versionedStreamProjection uuid initialUserProjection)
 
 updateStore :: Action (TimeStamped UserEvent) -> Store -> UUID -> IO ()
 updateStore = flip _sUpdate
@@ -190,10 +201,6 @@ updateStore = flip _sUpdate
 -- | An Action is a side-effect that runs on a particular stream's state and
 -- | reports what it did as events
 type Action e = UUID -> UserState -> IO [e]
-
-getLatestUserProjection r uuid = atomically $ getLatestStreamProjection r $
-    versionedStreamProjection uuid initialUserProjection
-writeEvents w uuid = void . atomically . storeEvents w uuid AnyPosition
 
 commandAction :: UserCommand -> DateTime -> Action (TimeStamped UserEvent)
 commandAction cmd t = \_ s -> do

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,6 +43,12 @@ packages:
     subdirs:
      - eventful-core
      - eventful-memory
+     - eventful-sql-common
+     - eventful-postgresql
+    extra-dep: true
+  - location:
+      git: git@github.com:thoughtbot/persistent-database-url.git
+      commit: 09782a464f4c50f91b78e118ae56010636cd38cd
     extra-dep: true
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)

--- a/warp-test.cabal
+++ b/warp-test.cabal
@@ -27,10 +27,14 @@ library
                      , datetime
                      , eventful-core
                      , eventful-memory
+                     , eventful-postgresql
+                     , eventful-sql-common
                      , http-types
                      , mime-mail
                      , neat-interpolation
                      , HaskellNet-SSL
+                     , persistent-database-url
+                     , persistent-postgresql
                      , stm
                      , time
                      , text

--- a/warp-test.cabal
+++ b/warp-test.cabal
@@ -21,6 +21,8 @@ library
                      , Registration
                      , Router
   build-depends:       base >= 4.7 && < 5
+                     , aeson
+                     , aeson-casing
                      , async
                      , bytestring
                      , cryptohash

--- a/warp-test.cabal
+++ b/warp-test.cabal
@@ -33,6 +33,7 @@ library
                      , eventful-sql-common
                      , http-types
                      , mime-mail
+                     , monad-logger
                      , neat-interpolation
                      , HaskellNet-SSL
                      , persistent-database-url


### PR DESCRIPTION
Now with added stays-around-after-you-shut-the-application.

I had a brief scare where verification wasn't working, until I realised I committed my code tweak I was using for tinkering where it times out verification after 10 seconds! That's back to 24 hrs in production now. The test still clocks it, so that's all good.

This has set me wondering - if we send you a verification link and you ignore it for 24 hrs, then click it, what do we do? Just provide a 404? Send you to the sign-up page again? Do we note in the small print of the email that you need to verify within a time limit?