### PR TITLE
Abstract ReadView

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -77,7 +77,7 @@ main = do
           (formatVLink $ scDomain serverConfig)
           (formatULink $ scDomain serverConfig)
 
-    withAsync (viewWorker pool (U.readChan o2)) $ \viewWorkerAsync -> do
+    withAsync (viewWorker userStateReadView pool (U.readChan o2)) $ \viewWorkerAsync -> do
         link viewWorkerAsync
         withAsync (mailer genEmail smtpSettings store (U.readChan o1)) $ \mailerAsync -> do
             link mailerAsync

--- a/src/ReadView.hs
+++ b/src/ReadView.hs
@@ -17,6 +17,7 @@ module ReadView
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Reader (ReaderT)
+import Data.Aeson (ToJSON, FromJSON)
 import Data.Pool (Pool)
 import Data.Text (Text)
 import Data.UUID (UUID)
@@ -57,9 +58,9 @@ erTableName = "email_registration"
 
 
 latestEvents
-  :: (MonadIO m)
+  :: (MonadIO m, ToJSON event, FromJSON event)
   => SequenceNumber
-  -> DB.SqlPersistT m [GlobalStreamEvent (TimeStamped UserEvent)]
+  -> DB.SqlPersistT m [GlobalStreamEvent event]
 latestEvents latestHandled =
     getEvents eventReader (eventsStartingAt () $ latestHandled + 1)
   where

--- a/src/ReadView.hs
+++ b/src/ReadView.hs
@@ -12,14 +12,16 @@ module ReadView
   , emailRegistrationEmailAddress
   , ViewSequenceNumberId
   , viewWorker
+  , userStateReadView
   ) where
 
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Reader (ReaderT)
 import Data.Aeson (ToJSON, FromJSON)
+import Data.Monoid
 import Data.Pool (Pool)
-import Data.Text (Text)
+import Data.Text (Text, unpack)
 import Data.UUID (UUID)
 import Database.Persist.Postgresql ((=.), (==.))
 import qualified Database.Persist.Postgresql as DB
@@ -35,15 +37,7 @@ import Eventful.Store.Sql (jsonStringSerializer, defaultSqlEventStoreConfig, sql
 import Registration (EmailAddress, UserEvent(..), TimeStamped, untilNothing)
 
 
-share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
-EmailRegistration
-    uuid UUID
-    emailAddress EmailAddress
-    verified Bool
-    UniqueEmailAddress emailAddress
-    UniqueUuid uuid
-    deriving Show
-
+share [mkPersist sqlSettings, mkMigrate "migrateVSN"] [persistLowerCase|
 ViewSequenceNumber
     name Text
     latestApplied SequenceNumber
@@ -51,10 +45,14 @@ ViewSequenceNumber
     deriving Show
 |]
 
--- FIXME: this constant needs to line up with what the template stuff above
--- produces, and is _not_ checked :-/
-erTableName :: Text
-erTableName = "email_registration"
+data ReadView event = ReadView
+  { rvTableName :: Text
+  , rvMigration :: DB.Migration
+  , rvUpdate :: UUID -> event -> ReaderT DB.SqlBackend IO ()
+  }
+
+instance Show (ReadView event) where
+    show rv = unpack $ "<ReadView " <> (rvTableName rv) <> ">"
 
 
 latestEvents
@@ -68,31 +66,26 @@ latestEvents latestHandled =
     eventReader = serializedGlobalEventStoreReader jsonStringSerializer jsonReader
 
 
-handleUserStateReadModelEvents
-  :: [GlobalStreamEvent (TimeStamped UserEvent)] -> ReaderT DB.SqlBackend IO ()
-handleUserStateReadModelEvents events = do
-    mapM_ (uncurry mutate . decomposeEvent) events
+handleReadViewEvents
+  :: ReadView event -> [GlobalStreamEvent event] -> ReaderT DB.SqlBackend IO ()
+handleReadViewEvents rv events = do
+    mapM_ (uncurry (rvUpdate rv) . decomposeEvent) events
     updateSN events
   where
-    mutate uuid (_, UserSubmitted email) = void $ DB.insertBy $
-        EmailRegistration uuid email False
-    mutate uuid (_, UserVerified) = DB.updateWhere
-        [EmailRegistrationUuid ==. uuid]
-        [EmailRegistrationVerified =. True]
-    mutate uuid (_, UserUnsubscribed) = DB.deleteBy $ UniqueUuid uuid
-    mutate _ _ = return ()
     decomposeEvent e = let e' = streamEventEvent e in
         (streamEventKey e', streamEventEvent e')
     updateSN [] = return ()
     updateSN es = let latestSN = streamEventPosition $ last es in
         DB.updateWhere
-          [ViewSequenceNumberName ==. erTableName]
+          [ViewSequenceNumberName ==. rvTableName rv]
           [ViewSequenceNumberLatestApplied =. latestSN]
 
 
-initialiseUserStateView :: ReaderT DB.SqlBackend IO ()
-initialiseUserStateView = DB.runMigration migrateAll >> void (
-    getOrInitSequenceNumber erTableName)
+initialiseReadView :: ReadView event -> ReaderT DB.SqlBackend IO ()
+initialiseReadView rv = do
+    DB.runMigration migrateVSN  -- Presumably OK to do evey time?
+    DB.runMigration $ rvMigration rv
+    void . getOrInitSequenceNumber $ rvTableName rv
 
 getOrInitSequenceNumber :: Text -> ReaderT DB.SqlBackend IO SequenceNumber
 getOrInitSequenceNumber tableName = do
@@ -102,15 +95,42 @@ getOrInitSequenceNumber tableName = do
     getN (ViewSequenceNumber _ n) = n
 
 
-updateUserStateView :: ReaderT DB.SqlBackend IO ()
-updateUserStateView =
-      getOrInitSequenceNumber erTableName >>=
-      latestEvents >>= handleUserStateReadModelEvents
+updateReadView
+  :: (ToJSON event, FromJSON event)
+  => ReadView event -> ReaderT DB.SqlBackend IO ()
+updateReadView rv =
+      getOrInitSequenceNumber (rvTableName rv) >>=
+      latestEvents >>= handleReadViewEvents rv
 
 
-viewWorker :: Pool DB.SqlBackend -> (IO (Maybe a)) -> IO ()
-viewWorker pool wait = DB.runSqlPool i pool >> f
+viewWorker
+  :: (ToJSON event, FromJSON event)
+  => ReadView event -> Pool DB.SqlBackend -> (IO (Maybe a)) -> IO ()
+viewWorker rv pool wait = DB.runSqlPool i pool >> f
   where
-    f = untilNothing wait (const $ DB.runSqlPool updateUserStateView pool)
-    i = DB.runMigration migrateAll >> initialiseUserStateView
-        >> updateUserStateView
+    f = untilNothing wait (const $ DB.runSqlPool (updateReadView rv) pool)
+    i = initialiseReadView rv >> updateReadView rv
+
+
+share [mkPersist sqlSettings, mkMigrate "migrateER"] [persistLowerCase|
+EmailRegistration
+    uuid UUID
+    emailAddress EmailAddress
+    verified Bool
+    UniqueEmailAddress emailAddress
+    UniqueUuid uuid
+    deriving Show
+|]
+
+-- FIXME: table name needs to line up with what the template stuff above
+-- produces, and is _not_ checked :-/
+userStateReadView :: ReadView (TimeStamped UserEvent)
+userStateReadView = ReadView  "email_registration" migrateER update
+  where
+    update uuid (_, UserSubmitted email) = void $ DB.insertBy $
+        EmailRegistration uuid email False
+    update uuid (_, UserVerified) = DB.updateWhere
+        [EmailRegistrationUuid ==. uuid]
+        [EmailRegistrationVerified =. True]
+    update uuid (_, UserUnsubscribed) = DB.deleteBy $ UniqueUuid uuid
+    update _ _ = return ()


### PR DESCRIPTION
This is the beginning of defining a migration away from our current tiny data model. The plan is to:
 * Define new (unused) event types for an extended data model, whilst keeping the old ones in place
 * Build a new `ReadView` that derives a new event log that uses the new types, whilst keeping the old log the canonical source of truth
 * Derive our actual email data `ReadView` from the new log
 * Switch writing of the event log to the new data type
 * Discard the old event log.