### PR TITLE
Define superset of existing events

### DIFF
--- a/src/Events.hs
+++ b/src/Events.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Events where
+
+import Data.Text (Text)
+import Data.UUID (UUID)
+import Data.ByteString (ByteString)
+
+import TH (mashSumTypes)
+import Registration (EmailAddress, EmailType)
+
+data EmailEvent
+  = EmailAddressSubmittedEmailEvent EmailAddress
+  | EmailAddressVerifiedEmailEvent
+  | EmailAddressRemovedEmailEvent
+  | EmailSentEmailEvent EmailType
+  deriving (Eq, Show)
+
+data AccountEvent
+  = AccountNameUpdatedAccountEvent Text
+  | AccountAddedEmailAddressAccountEvent UUID
+  | AccountRemovedEmailAddressAccountEvent UUID
+  | AccountAddedSessionAccountEvent UUID
+  | AccountRemovedSessionAccountEvent UUID
+  deriving (Eq, Show)
+
+type UserAgentString = ByteString
+
+data SessionEvent
+  = SessionSignedInSessionEvent UserAgentString
+  | SessionSignedOutSessionEvent
+  deriving (Eq, Show)
+
+mashSumTypes "Event" [''EmailEvent, ''AccountEvent, ''SessionEvent]

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Events where
 
@@ -32,3 +33,6 @@ data SessionEvent
   deriving (Eq, Show)
 
 mashSumTypes "Event" [''EmailEvent, ''AccountEvent, ''SessionEvent]
+
+deriving instance Eq Event
+deriving instance Show Event

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -7,7 +7,7 @@ import Data.Text (Text)
 import Data.UUID (UUID)
 import Data.ByteString (ByteString)
 
-import TH (mashSumTypes)
+import TH (unionSumTypes)
 import Registration (EmailAddress, EmailType)
 
 data EmailEvent
@@ -32,7 +32,7 @@ data SessionEvent
   | SessionSignedOutSessionEvent
   deriving (Eq, Show)
 
-mashSumTypes "Event" [''EmailEvent, ''AccountEvent, ''SessionEvent]
+unionSumTypes "Event" [''EmailEvent, ''AccountEvent, ''SessionEvent]
 
 deriving instance Eq Event
 deriving instance Show Event

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -3,6 +3,10 @@
 
 module Events where
 
+import Data.Aeson (ToJSON, toJSON, FromJSON, parseJSON)
+import Data.Aeson.Casing (aesonPrefix, camelCase)
+import Data.Aeson.TH (deriveJSON)
+import qualified Data.Aeson.Types as T
 import Data.Text (Text)
 import Data.UUID (UUID)
 import Data.ByteString (ByteString)
@@ -25,7 +29,14 @@ data AccountEvent
   | AccountRemovedSessionAccountEvent UUID
   deriving (Eq, Show)
 
-type UserAgentString = ByteString
+newtype UserAgentString =
+    UserAgentString {unUserAgentString :: Text} deriving (Eq, Show)
+
+instance ToJSON UserAgentString where
+    toJSON = T.String . unUserAgentString
+
+instance FromJSON UserAgentString where
+    parseJSON = T.withText "UserAgentString" $ pure . UserAgentString
 
 data SessionEvent
   = SessionSignedInSessionEvent UserAgentString
@@ -36,3 +47,5 @@ unionSumTypes "Event" [''EmailEvent, ''AccountEvent, ''SessionEvent]
 
 deriving instance Eq Event
 deriving instance Show Event
+
+deriveJSON (aesonPrefix camelCase) ''Event

--- a/src/ReadView.hs
+++ b/src/ReadView.hs
@@ -28,11 +28,13 @@ import qualified Database.Persist.Postgresql as DB
 import Database.Persist.TH (
     share, mkPersist, sqlSettings, mkMigrate, persistLowerCase)
 import Eventful (
-    SequenceNumber(..), GlobalStreamEvent,
+    SequenceNumber(..), EventVersion, GlobalStreamEvent,
     getEvents, eventsStartingAt, streamEventEvent, streamEventKey,
     streamEventPosition)
 import Eventful.Store.Postgresql (serializedGlobalEventStoreReader)
-import Eventful.Store.Sql (jsonStringSerializer, defaultSqlEventStoreConfig, sqlGlobalEventStoreReader)
+import Eventful.Store.Sql (
+    jsonStringSerializer, defaultSqlEventStoreConfig,
+    sqlGlobalEventStoreReader, JSONString)
 
 import Registration (EmailAddress, UserEvent(..), TimeStamped, untilNothing)
 
@@ -48,11 +50,23 @@ ViewSequenceNumber
 data ReadView event = ReadView
   { rvTableName :: Text
   , rvMigration :: DB.Migration
-  , rvUpdate :: UUID -> event -> ReaderT DB.SqlBackend IO ()
+  , rvUpdate :: SequenceNumber -> UUID -> EventVersion -> event -> ReaderT DB.SqlBackend IO ()
   }
 
 instance Show (ReadView event) where
     show rv = unpack $ "<ReadView " <> (rvTableName rv) <> ">"
+
+
+-- | A simple read view doesn't give you access to event version information
+--   from the event log, just events and the keys of the events streams for
+--   those events.
+simpleReadView
+  :: Text -> DB.Migration -> (UUID -> event -> ReaderT DB.SqlBackend IO ())
+  -> ReadView event
+simpleReadView tableName migration update =
+    ReadView tableName migration update'
+  where
+    update' _ uuid _ event = update uuid event
 
 
 latestEvents
@@ -69,11 +83,16 @@ latestEvents latestHandled =
 handleReadViewEvents
   :: ReadView event -> [GlobalStreamEvent event] -> ReaderT DB.SqlBackend IO ()
 handleReadViewEvents rv events = do
-    mapM_ (uncurry (rvUpdate rv) . decomposeEvent) events
+    mapM_ (applyUpdate . decomposeEvent) events
     updateSN events
   where
     decomposeEvent e = let e' = streamEventEvent e in
-        (streamEventKey e', streamEventEvent e')
+        ( streamEventPosition e
+        , streamEventKey e'
+        , streamEventPosition e'
+        , streamEventEvent e')
+    applyUpdate (globalPos, streamKey, streamPos, streamEventData) =
+        rvUpdate rv globalPos streamKey streamPos streamEventData
     updateSN [] = return ()
     updateSN es = let latestSN = streamEventPosition $ last es in
         DB.updateWhere
@@ -125,7 +144,7 @@ EmailRegistration
 -- FIXME: table name needs to line up with what the template stuff above
 -- produces, and is _not_ checked :-/
 userStateReadView :: ReadView (TimeStamped UserEvent)
-userStateReadView = ReadView  "email_registration" migrateER update
+userStateReadView = simpleReadView  "email_registration" migrateER update
   where
     update uuid (_, UserSubmitted email) = void $ DB.insertBy $
         EmailRegistration uuid email False

--- a/src/TH.hs
+++ b/src/TH.hs
@@ -9,9 +9,22 @@ import qualified Data.Text as Text
 
 import Language.Haskell.TH
 
-mashSumTypes :: String -> [Name] -> Q [Dec]
-mashSumTypes _ [] = return []
-mashSumTypes newNameStr typeNames =
+-- | Makes a new sum type with the given name from a list of (names of) other
+--   sum types. Note that the input types must have constructors suffixed with
+--   their type name. The newly constructed type will have constructors where
+--   the original type name suffix has been replaced with the name of the new
+--   type. E.g.
+--
+--   data FooType = Foo1FooType | Foo2FooType
+--   data BarType = BarBarType
+--   unionSumTypes "FooBarType" [''FooType, ''BarType]
+--
+--   provides
+--
+--   data FooBarType = Foo1FooBarType | Foo2FooBarType | BarFooBarType
+unionSumTypes :: String -> [Name] -> Q [Dec]
+unionSumTypes _ [] = return []
+unionSumTypes newNameStr typeNames =
   do
     newConstructors <- join <$> mapM mkNewConstructors typeNames
     return [DataD [] (mkName newNameStr) [] Nothing newConstructors []]

--- a/src/TH.hs
+++ b/src/TH.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module TH where
+
+import Control.Error.Util
+import Control.Monad (join)
+import Data.Text (pack, unpack)
+import qualified Data.Text as Text
+
+import Language.Haskell.TH
+
+mashSumTypes :: String -> [Name] -> Q [Dec]
+mashSumTypes _ [] = return []
+mashSumTypes newNameStr typeNames =
+  do
+    newConstructors <- join <$> mapM mkNewConstructors typeNames
+    return [DataD [] (mkName newNameStr) [] Nothing newConstructors []]
+  where
+    mkNewConstructors typeName = do
+      info <- reify typeName
+      case info of
+        (TyConI (DataD _ _ _ _ constructors _)) ->
+          either fail return $ mapM (modConstructor typeName) constructors
+        _ -> fail $ nameBase typeName ++ " must be a sum type"
+
+    modConstructor :: Name -> Con -> Either String Con
+    modConstructor typeName (NormalC conName args) =
+        (\n -> (NormalC (mkName $ n ++ newNameStr) args)) <$>
+        note "Constructor name missing type name suffix"
+          (stripNameSuffix typeName conName)
+    modConstructor _ _ = fail "Unrecognised constructor pattern"
+
+    stripNameSuffix :: Name -> Name -> Maybe String
+    stripNameSuffix suf = stripSuffix (nameBase suf) . nameBase
+
+
+stripSuffix :: String -> String -> Maybe String
+stripSuffix suf = fmap unpack . Text.stripSuffix (pack suf) . pack

--- a/warp-test.cabal
+++ b/warp-test.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   ghc-options:         -Wall
   exposed-modules:     Css
+                     , Events
                      , Lib
                      , Mailer
                      , Middleware
@@ -24,6 +25,7 @@ library
                      , Registration
                      , Router
                      , Templates
+                     , TH
                      , Types
   build-depends:       base >= 4.7 && < 5
                      , aeson
@@ -36,6 +38,7 @@ library
                      , datetime
                      , email-validate
                      , envy
+                     , errors
                      , eventful-core
                      , eventful-memory
                      , eventful-postgresql
@@ -53,6 +56,7 @@ library
                      , stm
                      , stringable
                      , time
+                     , template-haskell
                      , text
                      , text-format
                      , unagi-chan


### PR DESCRIPTION
With a sprinkling of Template Haskell :confused:. Then we make a new Read View that tracks the canonical event log, building a new log with the new event types, which we hope at somepoint to transition our read views to use, and then ditch the original log.